### PR TITLE
WIP: 🛷  Refactor git detection (rev-parse to zsh impl)

### DIFF
--- a/functions/git-info
+++ b/functions/git-info
@@ -11,9 +11,12 @@ unset git_info
 typeset -gA git_info
 
 # Return if not inside a Git repository work tree.
-if ! command git rev-parse --is-inside-work-tree &>/dev/null; then
-  return 1
-fi
+local __f=${0:A:h}
+while true; do
+  if [[ -d "${__f:A}/.git" ]]; then break; fi
+  if [[ ${__f:A} == "/" ]]; then return 1; fi
+  __f=${__f:A}/..
+done
 
 # Ignore submodule status.
 local ignore_submodules


### PR DESCRIPTION
The current implementation always calls git rev-parse. This means `git` will always be invoked, even if there is no git directory.

To demonstrate, zmodload zsh/zprof top of zshrc and run zprof (manually) after shell invocation.

If you have a phat home directory, the invocation of git-info can be seen consuming a fair bit of clock time. I don't think this actually fixes the "problem" of git-info consuming clock time, but it does reduce the number of instances `git rev-parse` will be invoked.

This implementation may also be buggy, or there may be a reason we're relying on the git rev-parse implementation that I don't recall.