### PR TITLE
Add support for more contexts

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,10 @@ following syntax to define custom styles for each context you want displayed:
 | remote    |  %R  | Remote name
 | stashed   |  %S  | Stashed states count
 | untracked |  %u  | Untracked files count (only when verbose mode enabled)
+| added     |  %a  | Added files count (only when verbose mode enabled)
+| modified  |  %m  | Modified files count (only when verbose mode enabled)
+| deleted   |  %d  | Deleted files count (only when verbose mode enabled)
+| renamed   |  %r  | Renamed files count (only when verbose mode enabled)
 
 While the commit and position contexts are only available when in ['detached
 HEAD' state], on the other hand, the ahead, behind, diverged, branch and remote

--- a/functions/git-info
+++ b/functions/git-info
@@ -131,8 +131,10 @@ else
       if [[ ${line:1:1} != ' ' ]] (( unindexed++ ))
 
       if [[ ${line:0:1} == 'A' ]] ((added++))
+      if [[ ${line:0:1} == 'M' ]] ((modified++))
       if [[ ${line:1:1} == 'M' ]] ((modified++))
       if [[ ${line:0:1} == 'D' ]] ((deleted++))
+      if [[ ${line:1:1} == 'D' ]] ((deleted++))
       if [[ ${line:0:1} == 'R' ]] ((renamed++))
       
     fi

--- a/functions/git-info
+++ b/functions/git-info
@@ -37,6 +37,7 @@ zstyle -s ':zim:git-info' ignore-submodules 'ignore_submodules' || ignore_submod
 
 local ahead_formatted behind_formatted branch_formatted clean_formatted \
     commit_formatted dirty_formatted indexed_formatted unindexed_formatted \
+    added_formatted deleted_formatted modified_formatted renamed_formatted \
     position_formatted remote_formatted action_formatted stashed_formatted \
     untracked_formatted diverged_formatted line
 
@@ -107,8 +108,16 @@ if ! zstyle -t ':zim:git-info' verbose; then
   if [[ -n ${indexed_format} || (${dirty} -eq 0 && (-n ${dirty_format} || -n ${clean_format})) ]]; then
     cmds+=("print -n 'i:'; command git diff-index --no-ext-diff --quiet --cached --ignore-submodules=${ignore_submodules} HEAD &>/dev/null; print \${?}")
   fi
+
+  local added_format
+  zstyle -s ':zim:git-info:added' format 'added_format'
+  
+  local deleted_format
+  zstyle -s ':zim:git-info:added' format 'deleted_format'
+  local modified_format
+  local renamed_format
 else
-  local -i indexed unindexed untracked
+  local -i indexed unindexed untracked added deleted modified renamed
   # Get current status.
   command git status --porcelain --ignore-submodules=${ignore_submodules} 2>/dev/null | while IFS= read -r line; do
     if [[ ${line:0:2} == '??' ]]; then
@@ -116,6 +125,12 @@ else
     else
       if [[ ${line:0:1} != ' ' ]] (( indexed++ ))
       if [[ ${line:1:1} != ' ' ]] (( unindexed++ ))
+
+      if [[ ${line:0:1} == 'A' ]] ((added++))
+      if [[ ${line:1:1} == 'M' ]] ((modified++))
+      if [[ ${line:1:1} == 'D' ]] ((deleted++))
+      if [[ ${line:0:1} == 'R' ]] ((renamed++))
+      
     fi
     (( dirty++ ))
   done
@@ -140,6 +155,35 @@ else
     zstyle -s ':zim:git-info:untracked' format 'untracked_format'
     zformat -f untracked_formatted ${untracked_format} "u:${untracked}"
   fi
+
+  # Format added
+  if (( added )); then
+    local added_format
+    zstyle -s ':zim:git-info:added' format 'added_format'
+    zformat -f added_formatted ${added_format} "a:${added}"
+  fi
+
+  # Format modified
+  if (( modified )); then
+    local modified_format
+    zstyle -s ':zim:git-info:modified' format 'modified_format'
+    zformat -f modified_formatted ${modified_format} "m:${modified}"
+  fi
+
+  # Format deleted
+  if (( deleted )); then
+    local deleted_format
+    zstyle -s ':zim:git-info:deleted' format 'deleted_format'
+    zformat -f deleted_formatted ${deleted_format} "d:${deleted}"
+  fi
+
+  # Format renamed
+  if (( renamed )); then
+    local renamed_format
+    zstyle -s ':zim:git-info:renamed' format 'renamed_format'
+    zformat -f renamed_formatted ${renamed_format} "r:${renamed}"
+  fi
+
 fi
 
 # Run cmds asynchronously.
@@ -212,6 +256,30 @@ if (( ${#cmds} )); then
             dirty=1
           fi
           ;;
+        a)
+          # Format added.
+          if (( ${line#a:} )); then
+            added_formatted=${added_format}
+          fi
+          ;;
+        m)
+          # Format modified.
+          if (( ${line#m:} )); then
+            modified_formatted=${modified_format}
+          fi
+          ;;
+        d)
+          # Format deleted.
+          if (( ${line#d:} )); then
+            deleted_formatted=${deleted_format}
+          fi
+          ;;
+        r)
+          # Format renamed.
+          if (( ${line#r:} )); then
+            renamed_formatted=${renamed_format}
+          fi
+          ;;
       esac
     fi
   done
@@ -243,7 +311,11 @@ for info_format in ${(k)info_formats}; do
     "s:${action_formatted}" \
     "S:${stashed_formatted}" \
     "u:${untracked_formatted}" \
-    "V:${diverged_formatted}"
+    "V:${diverged_formatted}" \
+    "a:${added_formatted}" \
+    "m:${modified_formatted}" \
+    "d:${deleted_formatted}" \
+    "r:${renamed_formatted}"
   git_info[${info_format}]=${reply}
 done
 

--- a/functions/git-info
+++ b/functions/git-info
@@ -114,8 +114,12 @@ if ! zstyle -t ':zim:git-info' verbose; then
   
   local deleted_format
   zstyle -s ':zim:git-info:added' format 'deleted_format'
+
   local modified_format
+  zstyle -s ':zim:git-info:added' format 'modified_format'
+
   local renamed_format
+  zstyle -s ':zim:git-info:added' format 'renamed_format'
 else
   local -i indexed unindexed untracked added deleted modified renamed
   # Get current status.

--- a/functions/git-info
+++ b/functions/git-info
@@ -128,7 +128,7 @@ else
 
       if [[ ${line:0:1} == 'A' ]] ((added++))
       if [[ ${line:1:1} == 'M' ]] ((modified++))
-      if [[ ${line:1:1} == 'D' ]] ((deleted++))
+      if [[ ${line:0:1} == 'D' ]] ((deleted++))
       if [[ ${line:0:1} == 'R' ]] ((renamed++))
       
     fi


### PR DESCRIPTION
I suggest this PR to add support for the following new contexts:
- added files (%a)
- modified files (%m)
- deleted files (%d)
- renamed files (%r)

These contexts are only available when verbose is set to `yes`.

I used the same code letters than [original prezto/git module](https://github.com/sorin-ionescu/prezto/blob/master/modules/git) for a better compatibility.

With this PR, we can have more information on the 'dirty' state as we now see the different reasons of why a repo is dirty.

Example of prompt:
```
#  zstyle ':zim:git-info' verbose 'yes'
#  zstyle ':zim:git-info:branch' format "%F{white}%b%f"
#  zstyle ':zim:git-info:clean' format "%F{green}✔%f"
#  zstyle ':zim:git-info:dirty' format "%F{red}≠%D%f|"
#  zstyle ':zim:git-info:added' format "%F{white}✚%a%f"
#  zstyle ':zim:git-info:deleted' format "%F{white}✖%d%f"
#  zstyle ':zim:git-info:modified' format "%F{white}●%m%f"
#  zstyle ':zim:git-info:untracked' format "%F{white}?%u%f"
#  zstyle ':zim:git-info:renamed' format "%F{white}r%r%f"
# zstyle ':zim:git-info:keys' format \
#   'status' '(%b|%C%D%a%m%d%r%u)'
(main|≠5|✚1●1✖1r1?1)
```